### PR TITLE
Add GitHub release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: Build and Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm ci
+      - run: npm run package
+      - run: npx vsce package -o jsonnet-renderer.vsix
+      - uses: actions/upload-artifact@v4
+        with:
+          name: extension
+          path: jsonnet-renderer.vsix
+
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: extension
+      - uses: softprops/action-gh-release@v1
+        with:
+          files: jsonnet-renderer.vsix


### PR DESCRIPTION
## Summary
- create GitHub Action to package the extension
- upload the packaged `.vsix` on tagged releases

## Testing
- `npm test` *(fails: Cannot find module 'os' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68796a892bf0832a9f6ad3dd45f829a2