### PR TITLE
Add bootstrap script for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,23 @@ Right-click on any `.jsonnet` or `.libsonnet` file in the **File Explorer**, and
    npm install
    ```
 
-3. **Build the extension**
+3. **Download CLI tools (Windows only)**
+
+   ```powershell
+   scripts/bootstrap.ps1
+   ```
+
+This script fetches `jq.exe`, `yq.exe` and extracts `jsonnet.exe` from the official
+`go-jsonnet` tarball if they are missing. The `scripts\bin` directory is added to
+your `PATH` for convenience.
+
+4. **Build the extension**
 
    ```bash
    npm run compile
    ```
 
-4. **Launch in VS Code**
+5. **Launch in VS Code**
 
    Press `F5` inside VS Code to open a new Extension Development Host.
    Open a `.jsonnet` file and enjoy the render panel or compare feature.

--- a/scripts/bootstrap.ps1
+++ b/scripts/bootstrap.ps1
@@ -1,0 +1,59 @@
+
+<#
+.SYNOPSIS
+Bootstraps jq, yq and jsonnet on Windows.
+#>
+param(
+    [string]$ToolsDir = "$PSScriptRoot\bin"
+)
+if (-not (Test-Path $ToolsDir)) {
+    New-Item -ItemType Directory -Path $ToolsDir | Out-Null
+}
+function Ensure-Tool {
+    param(
+        [string]$Command,
+        [string]$Url
+    )
+    if (Get-Command $Command -ErrorAction SilentlyContinue) {
+        Write-Host "$Command already available. Skipping."
+        return
+    }
+    $dest = Join-Path $ToolsDir "$Command.exe"
+    if (-not (Test-Path $dest)) {
+        Write-Host "Downloading $Command from $Url"
+        Invoke-WebRequest -Uri $Url -OutFile $dest
+    }
+    Write-Host "$Command installed at $dest"
+}
+
+function Ensure-Jsonnet {
+    param(
+        [string]$Url
+    )
+    $command = 'jsonnet'
+    if (Get-Command $command -ErrorAction SilentlyContinue) {
+        Write-Host "$command already available. Skipping."
+        return
+    }
+    $dest = Join-Path $ToolsDir "$command.exe"
+    if (-not (Test-Path $dest)) {
+        $archive = Join-Path $ToolsDir 'jsonnet.tar.gz'
+        Write-Host "Downloading $command from $Url"
+        Invoke-WebRequest -Uri $Url -OutFile $archive
+        Write-Host 'Extracting jsonnet.exe'
+        tar -xzf $archive -C $ToolsDir jsonnet.exe
+        Remove-Item $archive
+    }
+    Write-Host "$command installed at $dest"
+}
+function Add-ToolsToPath {
+    if (-not ($env:Path -split ';' | Where-Object { $_ -eq $ToolsDir })) {
+        Write-Host "Adding $ToolsDir to PATH"
+        [Environment]::SetEnvironmentVariable('Path', "$env:Path;$ToolsDir", 'User')
+        $env:Path += ';' + $ToolsDir
+    }
+}
+Ensure-Tool 'jq' 'https://github.com/stedolan/jq/releases/latest/download/jq-win64.exe'
+Ensure-Tool 'yq' 'https://github.com/mikefarah/yq/releases/latest/download/yq_windows_amd64.exe'
+Ensure-Jsonnet 'https://github.com/google/go-jsonnet/releases/download/v0.21.0/go-jsonnet_Windows_x86_64.tar.gz'
+Add-ToolsToPath


### PR DESCRIPTION
## Summary
- provide a PowerShell bootstrapper to fetch `jq`, `yq` and `jsonnet`
- mention the bootstrap step in the README

## Testing
- `npm run lint`
- `npm run compile`
- `npm test` *(fails: cannot find VS Code test config)*

------
https://chatgpt.com/codex/tasks/task_e_687a69ffa898832a92dfdd1cdd8ef44c