### PR TITLE
Add vsix install to bootstrap and include script in releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,9 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: extension
+      - uses: actions/checkout@v4
       - uses: softprops/action-gh-release@v1
         with:
-          files: jsonnet-renderer.vsix
+          files: |
+            jsonnet-renderer.vsix
+            scripts/bootstrap.ps1

--- a/README.md
+++ b/README.md
@@ -64,8 +64,9 @@ Right-click on any `.jsonnet` or `.libsonnet` file in the **File Explorer**, and
    ```
 
 This script fetches `jq.exe`, `yq.exe` and extracts `jsonnet.exe` from the official
-`go-jsonnet` tarball if they are missing. The `scripts\bin` directory is added to
-your `PATH` for convenience.
+`go-jsonnet` tarball if they are missing. It also downloads and installs the latest
+`jsonnet-renderer` extension (`.vsix` file) from this repository's releases. The
+`scripts\bin` directory is added to your `PATH` for convenience.
 
 4. **Build the extension**
 


### PR DESCRIPTION
## Summary
- update bootstrap script to install extension from latest release
- include bootstrap script in release assets
- document vsix install step in README

## Testing
- `npm ci`
- `npm test` *(fails: Could not find a .vscode-test file)*

------
https://chatgpt.com/codex/tasks/task_e_687d080f28a8832a86c72082ed587247