### PR TITLE
Fix release workflow artifact path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,10 +28,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
           name: extension
-      - uses: actions/checkout@v4
+      - run: mv extension/jsonnet-renderer.vsix ./
       - uses: softprops/action-gh-release@v1
         with:
           files: |


### PR DESCRIPTION
## Summary
- fix the path to the packaged `.vsix` in the release workflow

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d23e711a8832a97e734edc560fe2b