### PR TITLE
Fix release workflow artifact path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,10 +29,11 @@ jobs:
     needs: build
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - id: download
+        uses: actions/download-artifact@v4
         with:
           name: extension
-      - run: mv extension/jsonnet-renderer.vsix ./
+      - run: mv "${{ steps.download.outputs.download-path }}/jsonnet-renderer.vsix" ./
       - uses: softprops/action-gh-release@v1
         with:
           files: |


### PR DESCRIPTION
## Summary
- fix the release job path to the downloaded `.vsix`

## Testing
- `npx --version`


------
https://chatgpt.com/codex/tasks/task_e_687d2649bedc832a979f3ac7a6666c00