### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,9 +33,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: extension
-      - run: mv "${{ steps.download.outputs.download-path }}/jsonnet-renderer.vsix" ./
       - uses: softprops/action-gh-release@v1
         with:
           files: |
-            jsonnet-renderer.vsix
+            ${{ steps.download.outputs.download-path }}/jsonnet-renderer.vsix
             scripts/bootstrap.ps1


### PR DESCRIPTION
## Summary
- avoid moving the downloaded `.vsix`
- reference the downloaded path directly when creating the release

No tests were run because the repository does not include any.


------
https://chatgpt.com/codex/tasks/task_e_687d295fb384832abe30a6d5dd8eacce