### PR TITLE
Implement dependency watching for live preview

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jsonnet-renderer",
-  "version": "1.0.2",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jsonnet-renderer",
-      "version": "1.0.2",
+      "version": "1.0.4",
       "devDependencies": {
         "@types/mocha": "^10.0.10",
         "@types/node": "20.x",
@@ -21,7 +21,7 @@
         "typescript": "^5.8.3"
       },
       "engines": {
-        "vscode": "^1.101.0"
+        "vscode": "^1.102.0"
       }
     },
     "node_modules/@bcoe/v8-coverage": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "jsonnet-renderer",
   "displayName": "Jsonnet renderer",
   "description": "Render .jsonnet or .libsonnet into yaml",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "icon": "images/logo.png",
   "publisher": "dr. kosmos",
   "engines": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -151,9 +151,11 @@ export async function activate(context: vscode.ExtensionContext) {
     if (!session) {
       const sanitized = filePath.replace(/[^a-z0-9]/gi, '_');
       const virtualUri = vscode.Uri.parse(`rendered:live_${sanitized}.yaml`);
+      let deps = await utils.collectJsonnetDependencies(filePath);
       const watcher = vscode.workspace.onDidSaveTextDocument(async (doc) => {
-        if (doc.uri.fsPath === filePath) {
+        if (doc.uri.fsPath === filePath || deps.has(doc.uri.fsPath)) {
           try {
+            deps = await utils.collectJsonnetDependencies(filePath);
             const yaml = await utils.renderJsonnetToYaml(filePath);
             virtualDocs.set(virtualUri.toString(), yaml);
             changeEmitter.fire(virtualUri);


### PR DESCRIPTION
## Summary
- watch for jsonnet imports to refresh live preview when they change
- bump version to 1.0.4

## Testing
- `npm run lint`
- `npm run compile`


------
https://chatgpt.com/codex/tasks/task_e_688c6d57d400832aab786909c78dc6eb