### PR TITLE
Improve diff performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "jsonnet-renderer",
   "displayName": "Jsonnet renderer",
   "description": "Render .jsonnet or .libsonnet into yaml",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "icon": "images/logo.png",
   "publisher": "dr. kosmos",
   "engines": {


### PR DESCRIPTION
## Summary
- cache HEAD git worktree for Render & Compare and clean it up when the extension deactivates
- bump version to 1.0.5

## Testing
- `npm run compile`


------
https://chatgpt.com/codex/tasks/task_e_688c6faef834832a9c512af5399cb530